### PR TITLE
chore(scripts): organize package.json scripts by frontend and backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rest-express",
+  "name": "linkfy",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -3,20 +3,21 @@
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",
-  "scripts": {
-    "dev": "NODE_ENV=development tsx server/src/main.ts",
+   "scripts": {
+    "dev": "vite",
     "build": "vite build && esbuild server/src/main.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
-    "start": "NODE_ENV=production node dist/server/index.js",
-    "check": "tsc",
-    "db:push": "drizzle-kit push",
     "deploy": "gh-pages -d dist/public",
-    "nest:test": "jest --config server/test/jest-e2e.json",
-    "format": "prettier --write \"server/src/**/*.ts\" \"server/test/**/*.ts\"",
-    "lint": "eslint \"{server/src,server/apps,server/libs,server/test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
+    "nest:dev": "NODE_ENV=development tsx server/src/main.ts",
+    "nest:start": "NODE_ENV=production node dist/server/main.js",
+    "nest:check": "tsc",
+    "nest:db:push": "drizzle-kit push",
+    "nest:test:e2e": "jest --config server/test/jest-e2e.json",
+    "nest:test": "jest",
+    "nest:test:watch": "jest --watch",
+    "nest:test:cov": "jest --coverage",
+    "nest:test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "nest:lint": "eslint \"{server/src,server/apps,server/libs,server/test}/**/*.ts\" --fix",
+    "nest:format": "prettier --write \"server/src/**/*.ts\" \"server/test/**/*.ts\""
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
The scripts section in the package.json file was reorganized.

What was done:

- Frontend scripts (dev, build, deploy) remain at the top.
- Backend-related scripts were grouped under the nest: prefix:
  - nest:dev
  - nest:start
  - nest:test
  - nest:lint