### PR TITLE
feat(chrome-addon): create base structure for Chrome extension

### DIFF
--- a/chrome-addon/background.js
+++ b/chrome-addon/background.js
@@ -1,0 +1,6 @@
+console.log('Background script running');
+
+// Aquí puedes agregar lógica para manejar eventos de la extensión
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Linkfy extension installed');
+});

--- a/chrome-addon/manifest.json
+++ b/chrome-addon/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Linkfy",
+  "version": "1.0.0",
+  "description": "Extensión de Google Chrome para Linkfy.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["*://*/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/chrome-addon/popup.html
+++ b/chrome-addon/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Linkfy Popup</title>
+  </head>
+  <body>
+    <h1>Linkfy</h1>
+    <p>Convierte enlaces de YouTube a Spotify de manera sencilla.</p>
+  </body>
+</html>


### PR DESCRIPTION
The basic structure for the Google Chrome extension is created in the chrome-addon folder, including the initial files manifest.json, background.js, and popup.html.

📌 Note for verification:

- Open `chrome://extensions/` in Google Chrome.
- Enable Developer Mode.
- Click Load unpacked.
- Within the Linkfy project, select the chrome-addon folder.
- Confirm that the extension appears in the list and that the popup opens correctly when you click on the icon.