### PR TITLE
Feature/music service selector

### DIFF
--- a/client/src/components/music-service-demo.tsx
+++ b/client/src/components/music-service-demo.tsx
@@ -26,11 +26,11 @@ export default function MusicServiceDemo() {
             onSourceChange={setSourceService}
             onTargetChange={setTargetService}
           />
+
+          {/* Show selected services */}
           {(sourceService || targetService) && (
             <div className="mt-4 p-3 bg-gray-50 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 mb-2">
-                Selected:
-              </h4>
+              <h4 className="text-sm font-medium text-gray-700 mb-2">Selected:</h4>
               <p className="text-sm text-gray-600">
                 From: {sourceService || 'Not selected'}
               </p>

--- a/client/src/components/music-service-demo.tsx
+++ b/client/src/components/music-service-demo.tsx
@@ -26,11 +26,11 @@ export default function MusicServiceDemo() {
             onSourceChange={setSourceService}
             onTargetChange={setTargetService}
           />
-
-          {/* Show selected services */}
           {(sourceService || targetService) && (
             <div className="mt-4 p-3 bg-gray-50 rounded-lg">
-              <h4 className="text-sm font-medium text-gray-700 mb-2">Selected:</h4>
+              <h4 className="text-sm font-medium text-gray-700 mb-2">
+                Selected:
+              </h4>
               <p className="text-sm text-gray-600">
                 From: {sourceService || 'Not selected'}
               </p>

--- a/client/src/components/music-service-demo.tsx
+++ b/client/src/components/music-service-demo.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import MusicServiceSelector from './music-service-selector';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+type MusicService = 'YouTube Music' | 'Spotify' | 'SoundCloud';
+
+export default function MusicServiceDemo() {
+  const [sourceService, setSourceService] = useState<MusicService | null>(null);
+  const [targetService, setTargetService] = useState<MusicService | null>(null);
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <Card className="bg-white rounded-2xl shadow-lg">
+        <CardHeader>
+          <h2 className="text-xl font-semibold text-gray-800">
+            Music Service Converter
+          </h2>
+          <p className="text-sm text-gray-600">
+            Select your source and target music services
+          </p>
+        </CardHeader>
+        <CardContent>
+          <MusicServiceSelector
+            sourceService={sourceService}
+            targetService={targetService}
+            onSourceChange={setSourceService}
+            onTargetChange={setTargetService}
+          />
+
+          {/* Show selected services */}
+          {(sourceService || targetService) && (
+            <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+              <h4 className="text-sm font-medium text-gray-700 mb-2">Selected:</h4>
+              <p className="text-sm text-gray-600">
+                From: {sourceService || 'Not selected'}
+              </p>
+              <p className="text-sm text-gray-600">
+                To: {targetService || 'Not selected'}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/music-service-selector.tsx
+++ b/client/src/components/music-service-selector.tsx
@@ -65,7 +65,6 @@ export default function MusicServiceSelector({
 
   return (
     <div className="space-y-6">
-      {/* Source Service */}
       <div className="space-y-2">
         <Label htmlFor="source-service">From</Label>
         <Select
@@ -82,7 +81,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-          {/* 👇 fondo blanco + sombra + bordes redondeados */}
+
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"
@@ -102,8 +101,6 @@ export default function MusicServiceSelector({
           </SelectContent>
         </Select>
       </div>
-
-      {/* Target Service */}
       <div className="space-y-2">
         <Label htmlFor="target-service">To</Label>
         <Select
@@ -120,7 +117,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-          {/* 👇 mismo fix aquí */}
+
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"

--- a/client/src/components/music-service-selector.tsx
+++ b/client/src/components/music-service-selector.tsx
@@ -82,7 +82,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-          {/* 👇 fondo blanco + sombra + bordes redondeados */}
+
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"
@@ -120,7 +120,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-          {/* 👇 mismo fix aquí */}
+
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"

--- a/client/src/components/music-service-selector.tsx
+++ b/client/src/components/music-service-selector.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { SiSpotify, SiYoutubemusic, SiSoundcloud } from 'react-icons/si';
+
+type MusicService = 'YouTube Music' | 'Spotify' | 'SoundCloud';
+
+interface MusicServiceSelectorProps {
+  sourceService: MusicService | null;
+  targetService: MusicService | null;
+  onSourceChange: (service: MusicService | null) => void;
+  onTargetChange: (service: MusicService | null) => void;
+}
+
+const services: {
+  name: MusicService;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+}[] = [
+  { name: 'YouTube Music', icon: SiYoutubemusic, color: 'text-red-600' },
+  { name: 'Spotify', icon: SiSpotify, color: 'text-green-600' },
+  { name: 'SoundCloud', icon: SiSoundcloud, color: 'text-orange-500' },
+];
+
+const getServiceInfo = (serviceName: MusicService | null) => {
+  return services.find((s) => s.name === serviceName) || null;
+};
+
+export default function MusicServiceSelector({
+  sourceService,
+  targetService,
+  onSourceChange,
+  onTargetChange,
+}: MusicServiceSelectorProps) {
+  const handleSourceChange = (value: string) => {
+    const newSource = value === 'select' ? null : (value as MusicService);
+    onSourceChange(newSource);
+
+    if (targetService === newSource) {
+      onTargetChange(null);
+    }
+  };
+
+  const handleTargetChange = (value: string) => {
+    const newTarget = value === 'select' ? null : (value as MusicService);
+    onTargetChange(newTarget);
+
+    if (sourceService === newTarget) {
+      onSourceChange(null);
+    }
+  };
+
+  const getAvailableServices = (excludeService: MusicService | null) => {
+    return services.filter((service) => service.name !== excludeService);
+  };
+
+  const sourceInfo = getServiceInfo(sourceService);
+  const targetInfo = getServiceInfo(targetService);
+
+  return (
+    <div className="space-y-6">
+      {/* Source Service */}
+      <div className="space-y-2">
+        <Label htmlFor="source-service">From</Label>
+        <Select
+          value={sourceService || 'select'}
+          onValueChange={handleSourceChange}
+        >
+          <SelectTrigger id="source-service" className="flex items-center">
+            {sourceInfo ? (
+              <div className="flex items-center gap-2">
+                <sourceInfo.icon className={`w-4 h-4 ${sourceInfo.color}`} />
+                <span>{sourceInfo.name}</span>
+              </div>
+            ) : (
+              <SelectValue placeholder="Select Service" />
+            )}
+          </SelectTrigger>
+          {/* 👇 fondo blanco + sombra + bordes redondeados */}
+          <SelectContent
+            position="popper"
+            className="z-50 bg-white shadow-md rounded-md"
+          >
+            <SelectItem value="select">Select Service</SelectItem>
+            {getAvailableServices(targetService).map((service) => {
+              const IconComponent = service.icon;
+              return (
+                <SelectItem key={service.name} value={service.name}>
+                  <div className="flex items-center space-x-2">
+                    <IconComponent className={`w-4 h-4 ${service.color}`} />
+                    <span>{service.name}</span>
+                  </div>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Target Service */}
+      <div className="space-y-2">
+        <Label htmlFor="target-service">To</Label>
+        <Select
+          value={targetService || 'select'}
+          onValueChange={handleTargetChange}
+        >
+          <SelectTrigger id="target-service" className="flex items-center">
+            {targetInfo ? (
+              <div className="flex items-center gap-2">
+                <targetInfo.icon className={`w-4 h-4 ${targetInfo.color}`} />
+                <span>{targetInfo.name}</span>
+              </div>
+            ) : (
+              <SelectValue placeholder="Select Service" />
+            )}
+          </SelectTrigger>
+          {/* 👇 mismo fix aquí */}
+          <SelectContent
+            position="popper"
+            className="z-50 bg-white shadow-md rounded-md"
+          >
+            <SelectItem value="select">Select Service</SelectItem>
+            {getAvailableServices(sourceService).map((service) => {
+              const IconComponent = service.icon;
+              return (
+                <SelectItem key={service.name} value={service.name}>
+                  <div className="flex items-center space-x-2">
+                    <IconComponent className={`w-4 h-4 ${service.color}`} />
+                    <span>{service.name}</span>
+                  </div>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/music-service-selector.tsx
+++ b/client/src/components/music-service-selector.tsx
@@ -65,6 +65,7 @@ export default function MusicServiceSelector({
 
   return (
     <div className="space-y-6">
+      {/* Source Service */}
       <div className="space-y-2">
         <Label htmlFor="source-service">From</Label>
         <Select
@@ -81,7 +82,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-
+          {/* 👇 fondo blanco + sombra + bordes redondeados */}
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"
@@ -101,6 +102,8 @@ export default function MusicServiceSelector({
           </SelectContent>
         </Select>
       </div>
+
+      {/* Target Service */}
       <div className="space-y-2">
         <Label htmlFor="target-service">To</Label>
         <Select
@@ -117,7 +120,7 @@ export default function MusicServiceSelector({
               <SelectValue placeholder="Select Service" />
             )}
           </SelectTrigger>
-
+          {/* 👇 mismo fix aquí */}
           <SelectContent
             position="popper"
             className="z-50 bg-white shadow-md rounded-md"

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -13,7 +13,6 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-surface flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        {/* Header */}
         <div className="text-center mb-8">
           <div className="flex items-center justify-center mb-4">
             <SiYoutubemusic className="text-youtube text-2xl mr-2" />
@@ -26,7 +25,6 @@ export default function Home() {
           </p>
         </div>
 
-        {/* Music Service Selector */}
         <div className="mb-6">
           <MusicServiceSelector
             sourceService={sourceService}
@@ -36,10 +34,8 @@ export default function Home() {
           />
         </div>
 
-        {/* Conversion Form */}
         <ConversionForm />
 
-        {/* Footer */}
         <div className="text-center mt-8">
           <p className="text-xs text-gray-500">
             Perfect for Chrome extension • Privacy-focused • No data stored

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -13,6 +13,7 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-surface flex items-center justify-center p-4">
       <div className="w-full max-w-md">
+        {/* Header */}
         <div className="text-center mb-8">
           <div className="flex items-center justify-center mb-4">
             <SiYoutubemusic className="text-youtube text-2xl mr-2" />
@@ -25,6 +26,7 @@ export default function Home() {
           </p>
         </div>
 
+        {/* Music Service Selector */}
         <div className="mb-6">
           <MusicServiceSelector
             sourceService={sourceService}
@@ -34,8 +36,10 @@ export default function Home() {
           />
         </div>
 
+        {/* Conversion Form */}
         <ConversionForm />
 
+        {/* Footer */}
         <div className="text-center mt-8">
           <p className="text-xs text-gray-500">
             Perfect for Chrome extension • Privacy-focused • No data stored

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,8 +1,15 @@
 import ConversionForm from '@/components/conversion-form';
-import { Music, ArrowRight } from 'lucide-react';
+import MusicServiceSelector from '@/components/music-service-selector';
+import { ArrowRight } from 'lucide-react';
 import { SiYoutubemusic, SiSpotify } from 'react-icons/si';
+import { useState } from 'react';
+
+type MusicService = 'YouTube Music' | 'Spotify' | 'SoundCloud';
 
 export default function Home() {
+  const [sourceService, setSourceService] = useState<MusicService | null>(null);
+  const [targetService, setTargetService] = useState<MusicService | null>(null);
+
   return (
     <div className="min-h-screen bg-surface flex items-center justify-center p-4">
       <div className="w-full max-w-md">
@@ -17,6 +24,16 @@ export default function Home() {
           <p className="text-gray-600 text-sm">
             Convert YouTube Music links to Spotify instantly
           </p>
+        </div>
+
+        {/* Music Service Selector */}
+        <div className="mb-6">
+          <MusicServiceSelector
+            sourceService={sourceService}
+            targetService={targetService}
+            onSourceChange={setSourceService}
+            onTargetChange={setTargetService}
+          />
         </div>
 
         {/* Conversion Form */}


### PR DESCRIPTION
## Changes made

- Two drop-down menus have been added: one for the source service (From) and another for the destination service (To).
- Available options: YouTube Music, Spotify, and SoundCloud.
- Prevents selecting the same service in both drop-down menus.
- Displays the corresponding service icon next to each option.
- The default option is “Select service.”