### PR TITLE
bug(extension): Conditionally load i18n to avoid MV3 conflicts

### DIFF
--- a/client/src/AppExtension.tsx
+++ b/client/src/AppExtension.tsx
@@ -1,4 +1,3 @@
-import './i18n';
 import { queryClient } from './lib/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/components/ui/toaster';

--- a/client/src/popup.tsx
+++ b/client/src/popup.tsx
@@ -1,7 +1,17 @@
-import './i18n';
-
 import { createRoot } from 'react-dom/client';
 import AppExtension from './AppExtension';
 import './index.css';
+
+// We declare chrome as a global variable to avoid reference errors
+declare const chrome: any;
+
+// We initialize i18n conditionally if needed
+if (
+  typeof window !== 'undefined' &&
+  typeof chrome !== 'undefined' &&
+  chrome.runtime
+) {
+  import('./i18n');
+}
 
 createRoot(document.getElementById('root')!).render(<AppExtension />);


### PR DESCRIPTION
## Changes made:

- Removed direct i18n imports from `AppExtension.tsx` and `popup.tsx`.
- Added conditional initialization of i18n in popup.tsx, so translations are only loaded when the extension runs in a valid Chrome context.