### PR TITLE
Create assign-copilot.yml

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,19 +1,23 @@
 # Copilot Instructions for Linkfy
 
 ## Project Overview
+
 Linkfy is a full-stack TypeScript project for converting YouTube Music URLs to Spotify URLs, featuring real-time track preview and metadata extraction. It consists of:
+
 - **Frontend**: React (Vite, TypeScript, Tailwind CSS, shadcn/ui)
 - **Backend**: NestJS (TypeScript)
 - **Chrome Extension**: Manifest v3 compatible, shares code with client
 - **APIs**: Integrates YouTube Data API v3 and Spotify Web API
 
 ## Key Directories
+
 - `client/`: React app, UI components, hooks, API calls, localization
 - `server/`: NestJS backend, controllers, services, API integration
 - `shared/`: Common schemas and types
 - `chrome-addon/`: Chrome extension files (background, manifest, icons)
 
 ## Developer Workflows
+
 - **Install dependencies**: `yarn install` (root manages yarn workspace)
 - **Start dev server**: `yarn dev` (client)
 - **Run backend**: `yarn start` (server)
@@ -21,6 +25,7 @@ Linkfy is a full-stack TypeScript project for converting YouTube Music URLs to S
 - **Test endpoints**: Use HTTP files in `requests/` or Jest tests in `server/src/test/`
 
 ## Patterns & Conventions
+
 - **API requests**: Use TanStack Query in frontend (`client/src/lib/queryClient.ts`)
 - **Validation**: Zod schemas for request/response types (`shared/schema.ts`)
 - **Service boundaries**: Backend services in `server/src/services/` handle external API logic
@@ -30,24 +35,29 @@ Linkfy is a full-stack TypeScript project for converting YouTube Music URLs to S
 - **Extension**: Chrome extension uses code from `client/` for UI consistency
 
 ## Integration Points
+
 - **YouTube API**: Requires API key in `server/.env`, used in `server/src/services/youtube.service.ts`
 - **Spotify API**: Requires client ID/secret in `server/.env`, used in `server/src/services/spotify.service.ts`
 - **Supabase**: Used for storage/auth, configured in `client/src/lib/supabaseClient.ts` and `server/src/supabase/`
 
 ## Examples
+
 - To add a new music service, create a service in `server/src/services/`, update API endpoints in `server/src/controllers/`, and add UI in `client/src/components/`
 - For new UI patterns, extend shadcn/ui components in `client/src/components/ui/`
 
 ## Security & Testing
+
 - API keys/secrets must be in `.env` files (server/.env, client/.env) - never hardcoded
 - All endpoints validate input with Zod
 - Use Jest for backend tests (`server/src/test/`)
 
 ## Useful References
+
 - `README.md`: Setup, API, architecture overview
 - `shared/schema.ts`: Data models and validation
 - `client/src/lib/queryClient.ts`: API state management
 - `server/src/services/`: External API logic
 
 ---
+
 For unclear conventions or missing details, ask for clarification or review the README and key files above.

--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -1,0 +1,61 @@
+name: Assign Copilot Reviewer
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - master
+
+jobs:
+  assign-copilot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log PR Info
+        run: |
+          echo "Pull Request #${{ github.event.pull_request.number }}"
+          echo "Branch: ${{ github.event.pull_request.base.ref }}"
+          echo "Labels: ${{ toJson(github.event.pull_request.labels) }}"
+
+      - name: Check Conditions (labels/branches)
+        id: conditions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseBranch = pr.base.ref;
+            const labels = pr.labels.map(l => l.name);
+
+            // Condición: solo en develop o main con label "review-with-copilot"
+            if ((baseBranch === "develop" || baseBranch === "main") &&
+                labels.includes("review-with-copilot")) {
+              core.setOutput("shouldAssign", "true");
+            } else {
+              core.setOutput("shouldAssign", "false");
+            }
+
+      - name: Assign Copilot as Reviewer
+        if: steps.conditions.outputs.shouldAssign == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const prNumber = context.payload.pull_request.number;
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
+
+              const reviewers = ["github-copilot"];
+
+              const res = await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: prNumber,
+                reviewers: reviewers,
+              });
+
+              core.info(`✅ Copilot asignado como reviewer en PR #${prNumber}`);
+            } catch (error) {
+              core.warning(`⚠️ No se pudo asignar a Copilot: ${error.message}`);
+              core.setFailed("Error al intentar asignar reviewer.");
+            }


### PR DESCRIPTION
- Se creó un workflow .github/workflows/assign-copilot.yml.
- El flujo se ejecuta en eventos pull_request (opened, reopened, ready_for_review).
- Uso de la acción actions/github-script para llamar a la API de GitHub y asignar al reviewer.
- Manejo de errores con try/catch y logging (core.info, core.warning).