### PR TITLE
refactor: remove footer from home page

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,7 +1,6 @@
 {
   "home": {
-    "description": "Convert YouTube Music links to Spotify instantly",
-    "footer": "Perfect for Chrome extension • Privacy-focused • No data stored"
+    "description": "Convert YouTube Music links to Spotify instantly"
   },
   "conversion": {
     "successTitle": "Success!",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -1,7 +1,6 @@
 {
   "home": {
-    "description": "Convierte enlaces de YouTube Music a Spotify al instante",
-    "footer": "Perfecto para la extensión de Chrome • Enfocado en la privacidad • Sin almacenar datos"
+    "description": "Convierte enlaces de YouTube Music a Spotify al instante"
   },
   "conversion": {
     "successTitle": "¡Éxito!",

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -64,11 +64,6 @@ export default function Home() {
 
         {/* Conversion Form */}
         <ConversionForm />
-
-        {/* Footer */}
-        <div className="text-center mt-8">
-          <p className="text-xs text-gray-500">{t('home.footer')}</p>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- Se eliminó el bloque JSX del footer en home.tsx.
- Se borró la clave de traducción home.footer en en.json y es.json.
- Se verificó que el layout se renderiza correctamente sin el footer.