### PR TITLE
fix(routing): configure Wouter to serve main app only on root path

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -12,7 +12,7 @@ Sentry.init({
 });
 
 createRoot(document.getElementById('root')!).render(
-  <Router base={import.meta.env.DEV ? '/' : '/linkfy'}>
+  <Router base={'/'}>
     <App />
   </Router>,
 );

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
- Ensure root path (/) loads main application component
- Prevent other paths like /linkfy from loading home page
- Verified local Vite routing and Vercel deployment