### PR TITLE
fix: Corrige la redirección de autenticación en Vercel

### DIFF
--- a/client/.env.development.example
+++ b/client/.env.development.example
@@ -19,6 +19,7 @@ VITE_API_URL=http://localhost:3000
 # Replace with your actual Supabase URL and anonymous key.
 VITE_SUPABASE_URL=your-supabase-url-here
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key-here
+VITE_SITE_URL=http://localhost:5173
 
 # Sentry
 # -----------------------------------------------------------------------------

--- a/client/src/lib/supabaseClient.ts
+++ b/client/src/lib/supabaseClient.ts
@@ -61,6 +61,8 @@ export const getAuthHeaders = async () => {
 };
 
 export const getRedirectUrl = () => {
-  const base = window.location.origin;
-  return `${base}/auth`;
+  const url =
+    import.meta.env.VITE_SITE_URL ||
+    (typeof window !== 'undefined' ? window.location.origin : '');
+  return `${url}/auth`;
 };


### PR DESCRIPTION
La URL de redirección de autenticación de Supabase ahora es configurable a través de la variable de entorno `VITE_SITE_URL`. Esto soluciona un problema por el que la redirección fallaba en los despliegues de Vercel porque `window.location.origin` no siempre es la URL base correcta.

La función `getRedirectUrl` en `client/src/lib/supabaseClient.ts` ha sido actualizada para usar `VITE_SITE_URL` si está definida, recurriendo a `window.location.origin` en caso contrario. La variable `VITE_SITE_URL` también ha sido añadida a `.env.development.example`.